### PR TITLE
Added methods and removal of trailing whitespace

### DIFF
--- a/HelpSource/Classes/AbstractVector.schelp
+++ b/HelpSource/Classes/AbstractVector.schelp
@@ -20,7 +20,7 @@ Applies the gramSchmidt process to the vectors and returns an array of orthogona
 NOTE::
 rounding errors will usually not give you completely orthogonal vectors.
 ::
-	
+
 code::
 a = RealVector[1,2];
 b = RealVector[3,4];
@@ -92,6 +92,19 @@ projects vector into the current vector.
 
 code::
 RealVector[0,0,1].proj(RealVector[3.2,5.6,3.6])
+::
+
+METHOD:: clip
+Clips a vector in all dimensions.
+
+ARGUMENT:: min
+The minimum.
+
+ARGUMENT: max
+The maximum.
+
+code::
+RealVector[10,-4,2].clip(-2,5);
 ::
 
 EXAMPLES::

--- a/HelpSource/Classes/RealVector.schelp
+++ b/HelpSource/Classes/RealVector.schelp
@@ -59,3 +59,13 @@ METHOD:: theta
 code::
 RealVector[0,1].theta/(2pi)*360
 ::
+
+METHOD:: zero
+Make a zero vector
+
+ARGUMENT:: dim
+Dimensions of the vector. This is not needed for code::RealVector2D.zero:: or code::RealVector3D.zero::.
+
+code::
+RealVector.zero(5); // a five-dimensional zero vector
+::

--- a/Vector.sc
+++ b/Vector.sc
@@ -35,6 +35,12 @@ AbstractVector[slot] : ArrayedCollection {
 		if(this.norm > max, { ^this.normalize * max })
 	}
 
+	clip {|min, max|
+		this.do{|val, i|
+			this[i] = this[i].clip(min,max);
+		};
+	}
+
 	isOrthogonal { |vector|
 		^(this <|> vector) == 0
 	}
@@ -51,6 +57,10 @@ AbstractVector[slot] : ArrayedCollection {
 
 	asRealVector2D {
 		^RealVector2D[this.x, this.y]
+	}
+
+	asRealVector3D {
+		^RealVector3D[this.x, this.y, this.z]
 	}
 
 	angle{ |vector|
@@ -82,6 +92,10 @@ AbstractVector[slot] : ArrayedCollection {
 		}
 	}
 
+	isVector {
+		^true;
+	}
+
 }
 
 // for vectors in R^N
@@ -99,6 +113,11 @@ RealVector[slot] : AbstractVector {
 
 	*rand2D { |xlo, xhi, ylo, yhi|
 		^this.newFrom([rrand(xlo, xhi), rrand(ylo, yhi)])
+	}
+
+	// a zero vector
+	*zero { |size|
+		^this.newFrom(Array.fill(size, {0}))
 	}
 
 	//inner product
@@ -173,6 +192,10 @@ ComplexVector[slot] : AbstractVector {
 //--2d vector optimised for speed, around 10% faster.
 RealVector2D[slot] : RealVector {
 
+	*zero {
+		^this.newFrom([0,0]);
+	}
+
 	norm {
 		^this[0].sumsqr(this[1]).sqrt
 	}
@@ -185,12 +208,23 @@ RealVector2D[slot] : RealVector {
 		^(this[0] * vec[0]) + (this[1] * vec[1])
 	}
 
+	rotate {|angle|
+		var x, y;
+		x = (cos(angle)*this[0]) - (sin(angle)*this[1]);
+		y = (sin(angle)*this[0]) + (cos(angle)*this[1]);
+		^RealVector2D[x,y];
+	}
+
 	asRealVector2D { ^this }
 
 }
 
 //--3d vector optimised for speed, around 10% faster.
 RealVector3D[slot] : RealVector {
+
+	*zero {
+		^this.newFrom([0,0,0]);
+	}
 
 	norm {
 		^(this[0].sumsqr(this[1]) + this[2].pow(2)).sqrt
@@ -212,6 +246,10 @@ RealVector3D[slot] : RealVector {
 	}
 
 	phi { ^atan2(this[2], (this[0].squared + this[1].squared).sqrt) }
+
+	azi {
+		^atan2(this[1], this[0])
+	}
 
 	asRealVector3D{ ^this }
 

--- a/Vector.sc
+++ b/Vector.sc
@@ -92,10 +92,6 @@ AbstractVector[slot] : ArrayedCollection {
 		}
 	}
 
-	isVector {
-		^true;
-	}
-
 }
 
 // for vectors in R^N

--- a/Vector.sc
+++ b/Vector.sc
@@ -1,50 +1,50 @@
-// ©2009 Miguel Negrão, Fredrik Olofsson
+// Copyright 2009 Miguel Negr√£o, Fredrik Olofsson
 // GPLv3 - http://www.gnu.org/licenses/gpl-3.0.html
 
 //Vector class for vectors of any dimension, with optimized classes for 2D and 3D.
 
 AbstractVector[slot] : ArrayedCollection {
-	
+
 	species { ^this.class }
-	
+
 	//usual notation up to 3D vectors
 	x { ^this.at(0) }
-	
+
 	y { ^this.at(1) }
-	
-	z { ^this.at(2) }	
-	
+
+	z { ^this.at(2) }
+
 	//inner product
-	<|> { |vec| 
-		^this.subclassResponsibility 
+	<|> { |vec|
+		^this.subclassResponsibility
 	}
-	
+
 	norm {
 		^(this <|> this).sqrt
 	}
-	
+
 	dist { |vec|
 		^(this - vec).norm
 	}
-	
+
 	normalize {
 		^this / this.norm
 	}
-	
+
 	limit { |max|
 		if(this.norm > max, { ^this.normalize * max })
 	}
-	
+
 	isOrthogonal { |vector|
 		^(this <|> vector) == 0
 	}
-	
+
 	asAbstractVector { ^this }
-	
+
 	asPoint {
 		^Point(this[0],this[1])
 	}
-	
+
 	asRealVector {
 		^RealVector[this.x, this.y]
 	}
@@ -52,26 +52,26 @@ AbstractVector[slot] : ArrayedCollection {
 	asRealVector2D {
 		^RealVector2D[this.x, this.y]
 	}
-	
+
 	angle{ |vector|
 		^acos((this<|>vector)/(this.norm*vector.norm))
 	}
-	
+
 	transpose{
 		^this.asMatrix.flop
 	}
-	
+
 	asMatrix{
-		^Matrix.with(this.collect{ |a| [a] })		
+		^Matrix.with(this.collect{ |a| [a] })
 	}
-	
+
 	//project a vector onto this vector
 	proj{ |vector|
 		^this*(this<|>vector)/(this<|>this)
 	}
-	
+
 	*gramSchmidt{ |vectors|
-		
+
 		^vectors.collect{ |vector1,j|
 			vectors.do{ |vector2,k|
 				if(j<k){
@@ -79,14 +79,14 @@ AbstractVector[slot] : ArrayedCollection {
 				}
 			};
 			vector1.normalize;
-		}		
+		}
 	}
-		
+
 }
 
 // for vectors in R^N
 RealVector[slot] : AbstractVector {
-	
+
 	species {^this.class}
 
 	*canonB { |i,size|
@@ -96,15 +96,15 @@ RealVector[slot] : AbstractVector {
 	*rand { |size = 2, lo = 0.0, hi = 1.0|
 		^this.newFrom(size.collect { rrand(lo, hi) })
 	}
-		
+
 	*rand2D { |xlo, xhi, ylo, yhi|
 		^this.newFrom([rrand(xlo, xhi), rrand(ylo, yhi)])
-	}	
-	
+	}
+
 	//inner product
-	<|> { |vec|	
+	<|> { |vec|
 		var size = this.size;
-		
+
 		if(size == 2) {
 			^(this[0] * vec[0]) + (this[1] * vec[1])
 		}{
@@ -117,9 +117,9 @@ RealVector[slot] : AbstractVector {
 			}
 		}
 	}
-	
+
 	//outerProduct
-	cross { |vector| 
+	cross { |vector|
 		var a1, a2, a3, b1, b2, b3;
 		#a1, a2, a3 = this;
 		#b1, b2, b3 = vector;
@@ -128,7 +128,7 @@ RealVector[slot] : AbstractVector {
 
 	norm {
 		var size = this.size;
-		
+
 		if(size == 2) {
 			^this[0].sumsqr(this[1]).sqrt
 		}{
@@ -139,10 +139,10 @@ RealVector[slot] : AbstractVector {
 			}
 		}
 	}
-	
+
 	dist { |vec|
 		var size = this.size;
-		
+
 		if(size == 2){
 			^(vec[0]-this[0]).hypot(vec[1]-this[1])
 		}{
@@ -153,16 +153,16 @@ RealVector[slot] : AbstractVector {
 			}
 		}
 	}
-	
-	theta { 
+
+	theta {
 		^atan2(this.at(1), this.at(0))
 	}
-	
+
 }
 
 //vectors in C^N
 ComplexVector[slot] : AbstractVector {
-	
+
 	<|> { |vec|
 		^this.sum { |item, i|
 			item * vec[i].conjugate
@@ -172,35 +172,35 @@ ComplexVector[slot] : AbstractVector {
 
 //--2d vector optimised for speed, around 10% faster.
 RealVector2D[slot] : RealVector {
-	
+
 	norm {
 		^this[0].sumsqr(this[1]).sqrt
 	}
-	
-	dist { |vec| 
+
+	dist { |vec|
 		^(vec[0] - this[0]).hypot(vec[1] - this[1])
 	}
-	
-	<|> { |vec| 
+
+	<|> { |vec|
 		^(this[0] * vec[0]) + (this[1] * vec[1])
 	}
-	
+
 	asRealVector2D { ^this }
-	
+
 }
 
 //--3d vector optimised for speed, around 10% faster.
 RealVector3D[slot] : RealVector {
-	
+
 	norm {
 		^(this[0].sumsqr(this[1]) + this[2].pow(2)).sqrt
 	}
-	
-	dist { |vec| 
+
+	dist { |vec|
 		^(vec[0] - this[0]).hypot((vec[1] - this[1]).hypot(vec[2] - this[2]))
 	}
-	
-	<|> { |vec| 
+
+	<|> { |vec|
 		^(this[0] * vec[0]) + (this[1] * vec[1]) + (this[2] * vec[2])
 	}
 
@@ -217,12 +217,12 @@ RealVector3D[slot] : RealVector {
 
 }
 
-+ Point {	
-	
++ Point {
+
 	asRealVector {
 		^RealVector[x, y]
 	}
-	
+
 	asRealVector2D {
 		^RealVector2D[x, y]
 	}
@@ -230,8 +230,8 @@ RealVector3D[slot] : RealVector {
 
 + SimpleNumber {
 
-    asRealVector3D{
-        ^3.collect{ this }.as(RealVector3D)
-    }
+		asRealVector3D{
+				^3.collect{ this }.as(RealVector3D)
+		}
 
 }


### PR DESCRIPTION
New methods (`zero`, `clip`, `RealVector.asRealVector3D`, `isVector`, `RealVector2D.rotate`, `RealVector3D.azi`). Removed of trailing whitespace. Parsed into two different commits (one for whitespace, one for the added methods) for easier review.

Rebased repo from the old pull request I'd made. Tabs have not been changed to spaces.