### PR TITLE
Clip input to acos() to fix nan.

### DIFF
--- a/Vector.sc
+++ b/Vector.sc
@@ -64,7 +64,7 @@ AbstractVector[slot] : ArrayedCollection {
 	}
 
 	angle{ |vector|
-		^acos((this<|>vector)/(this.norm*vector.norm))
+		^acos(((this<|>vector)/(this.norm*vector.norm)).clip(-1,1))
 	}
 
 	transpose{


### PR DESCRIPTION
Speaking of bugs, here's one. 

```
a = RealVector2D.newFrom([3,-2]);
b = RealVector2D.newFrom([3,-2]);
x = a.angle(b); // returns nan
x.postln; // 1.0
x == 1.0; // false
x-1; // 2.2204460492503e-16
```

`a.angle(b)` should return 0 since the two vectors are identical. There's a precision error that happens when getting the norm of the vector that puts the input of `acos` outside the bounds of it's acceptable input.